### PR TITLE
Update cdk-tips-01-how-to-use-local-cdk-commands.md

### DIFF
--- a/src/articles/2020/cdk-tips-01-how-to-use-local-cdk-commands.md
+++ b/src/articles/2020/cdk-tips-01-how-to-use-local-cdk-commands.md
@@ -176,7 +176,8 @@ which ships with all modern distributions of NodeJS.
 So, instead of invoking `cdk init --language=<lang>`
 you would call `npx cdk init --language`,
 and `npx` will download the latest version of the `aws-cdk` package,
-and store it in a temporary directory. You can use a specific `aws-cdk` package version if needed:
+and store it in a temporary directory.
+You can use a specific `aws-cdk` package version if needed:
 `npx cdk@1.44.0 init --language`.
 The end effect will be the same,
 without the need for installing anything globally.

--- a/src/articles/2020/cdk-tips-01-how-to-use-local-cdk-commands.md
+++ b/src/articles/2020/cdk-tips-01-how-to-use-local-cdk-commands.md
@@ -176,9 +176,10 @@ which ships with all modern distributions of NodeJS.
 So, instead of invoking `cdk init --language=<lang>`
 you would call `npx cdk init --language`,
 and `npx` will download the latest version of the `aws-cdk` package,
-and store it in a temporary directory.
-You can use a specific `aws-cdk` package version if needed:
-`npx cdk@1.44.0 init --language`.
+and store it in a temporary directory
+(if you want to use a specific version of the CDK, instead of the latest,
+you can do it by adding a version specifier to the command,
+like `npx cdk@1.98.0 init --language=<lang>`).
 The end effect will be the same,
 without the need for installing anything globally.
 After the project has been initiated,

--- a/src/articles/2020/cdk-tips-01-how-to-use-local-cdk-commands.md
+++ b/src/articles/2020/cdk-tips-01-how-to-use-local-cdk-commands.md
@@ -176,7 +176,8 @@ which ships with all modern distributions of NodeJS.
 So, instead of invoking `cdk init --language=<lang>`
 you would call `npx cdk init --language`,
 and `npx` will download the latest version of the `aws-cdk` package,
-and store it in a temporary directory.
+and store it in a temporary directory. You can use a specific `aws-cdk` package version if needed:
+`npx cdk@1.44.0 init --language`.
 The end effect will be the same,
 without the need for installing anything globally.
 After the project has been initiated,


### PR DESCRIPTION
Add a description of how to specify an explicit version for `aws-cdk` package when running `cdk init` using `npx`